### PR TITLE
feat : 도서 주문 상태 추가 #28

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,7 +138,7 @@ build/
 gradle-app.setting
 
 # Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
-!gradle-wrapper.jar
+!gradle-wrapper.jarb
 
 # Cache of project
 .gradletasknamecache

--- a/src/main/java/com/nhnacademy/illuwa/d_book/book/entity/Book.java
+++ b/src/main/java/com/nhnacademy/illuwa/d_book/book/entity/Book.java
@@ -1,5 +1,6 @@
 package com.nhnacademy.illuwa.d_book.book.entity;
 
+import com.nhnacademy.illuwa.d_book.book.enums.orderStatus;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,7 +13,6 @@ import java.util.Date;
 @Getter
 @NoArgsConstructor
 public class Book {
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -41,5 +41,5 @@ public class Book {
 
     private boolean isGiftWrap;
 
-
+    private orderStatus status;
 }

--- a/src/main/java/com/nhnacademy/illuwa/d_book/book/enums/orderStatus.java
+++ b/src/main/java/com/nhnacademy/illuwa/d_book/book/enums/orderStatus.java
@@ -1,0 +1,8 @@
+package com.nhnacademy.illuwa.d_book.book.enums;
+
+public enum orderStatus {
+    AVAILABLE,
+    SOLD_OUT,
+    DISCONTINUED,
+    DELETED
+}


### PR DESCRIPTION
## 📝작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명
- 오전에 스크럼 회의 때 언급되었던 도서 상태를 추가했습니다.
- 상태 변경을 추적하지 않고, 주문 상태만 확인 할 필요가 있기 때문에 Enum 타입의 필드를 생성해서 관리해보려고 합니다.

## 💬리뷰 요구사항(선택)
- .

## Issue Tags
> 아래 # 태그 뒤에 이슈 번호 붙여주세요!
- Closed: #28 
