### PR TITLE
book(feat):

### DIFF
--- a/src/main/java/com/nhnacademy/illuwa/d_book/book/controller/BookController.java
+++ b/src/main/java/com/nhnacademy/illuwa/d_book/book/controller/BookController.java
@@ -66,6 +66,18 @@ public class BookController {
         return ResponseEntity.ok(bestSellerList);
     }
 
+    @GetMapping("/search/criteria")
+    public ResponseEntity<Page<BookDetailResponse>> searchBooksByCriteria(
+            @RequestParam(required = false) Long categoryId,
+            @RequestParam(required = false) String tagName,
+            Pageable pageable) {
+
+        Page<BookDetailResponse> BooksByCriteria
+                = bookService.searchBooksByCriteria(categoryId, tagName, pageable);
+        return ResponseEntity.ok(BooksByCriteria);
+    }
+
+
 
 
 }

--- a/src/main/java/com/nhnacademy/illuwa/d_book/book/repository/BookRepositoryCustomImpl.java
+++ b/src/main/java/com/nhnacademy/illuwa/d_book/book/repository/BookRepositoryCustomImpl.java
@@ -4,14 +4,21 @@ import com.nhnacademy.illuwa.d_book.book.entity.Book;
 import com.nhnacademy.illuwa.d_book.book.entity.QBook;
 import com.nhnacademy.illuwa.d_book.category.entity.QBookCategory;
 import com.nhnacademy.illuwa.d_book.tag.entity.QBookTag;
+import com.nhnacademy.illuwa.d_book.tag.entity.QTag;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
 
+import java.util.ArrayList;
 import java.util.List;
 
+@Repository
 public class BookRepositoryCustomImpl implements BookRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
@@ -22,6 +29,55 @@ public class BookRepositoryCustomImpl implements BookRepositoryCustom {
 
     @Override
     public Page<Book> findBooksByCriteria(Long categoryId, String tagName, Pageable pageable) {
-        return null;
+        QBook book = QBook.book;
+        QBookCategory bookCategory = QBookCategory.bookCategory;
+        QBookTag bookTag = QBookTag.bookTag;
+        QTag tag = QTag.tag;
+
+        JPAQuery<Book> query = queryFactory.select(book).distinct().from(book);
+
+
+        List<BooleanExpression> conditions = new ArrayList<>();
+
+
+        if (categoryId != null) {
+
+            query.join(bookCategory).on(bookCategory.book.id.eq(book.id));
+
+            conditions.add(bookCategory.category.id.eq(categoryId));
+        }
+
+
+        if (StringUtils.hasText(tagName)) {
+
+            query.join(bookTag).on(bookTag.book.id.eq(book.id));
+
+            query.join(tag).on(bookTag.tag.id.eq(tag.id));
+
+            conditions.add(tag.name.eq(tagName));
+        }
+
+        query.where(conditions.toArray(new BooleanExpression[0]));
+
+
+        List<Book> content = query
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+
+        JPAQuery<Long> countQuery = queryFactory.select(book.countDistinct()).from(book);
+        if (categoryId != null) {
+            countQuery.join(bookCategory).on(bookCategory.book.id.eq(book.id));
+        }
+        if (StringUtils.hasText(tagName)) {
+            countQuery.join(bookTag).on(bookTag.book.id.eq(book.id));
+            countQuery.join(tag).on(bookTag.tag.id.eq(tag.id));
+        }
+        countQuery.where(conditions.toArray(new BooleanExpression[0]));
+
+        long total = countQuery.fetchOne();
+
+        return new PageImpl<>(content, pageable, total);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,7 +5,7 @@ spring:
     import: optional:configserver:https://book1lluwa.store/config/
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create-drop
     show-sql: true
     properties:
       hibernate:

--- a/src/test/java/com/nhnacademy/illuwa/d_book/bookCategory/repository/CustomizedBookCategoryRepositoryImplTest.java
+++ b/src/test/java/com/nhnacademy/illuwa/d_book/bookCategory/repository/CustomizedBookCategoryRepositoryImplTest.java
@@ -11,9 +11,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -21,6 +23,7 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
+@ActiveProfiles("test")
 @Import(QuerydslConfig.class)
 public class CustomizedBookCategoryRepositoryImplTest {
 
@@ -46,6 +49,7 @@ public class CustomizedBookCategoryRepositoryImplTest {
                 .bookExtraInfo(new BookExtraInfo(Status.DELETED, true, 1))
                 .build();
         entityManager.persist(book);
+        entityManager.flush();
         this.bookId = book.getId();
 
         Category category1 = new Category("카테고리1");

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,13 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=MySQL
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: true
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect


### PR DESCRIPTION
- QueryDSL을 통한 category-tag-paging api 추가
- 테스트코드 수정
- test.yml 생성

## 📝작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명
- 테스트 코드 수정
- test.yml 추가
- QueryDSL 로직을 사용해서 tag와 category를 query parameter로 받아서 paging 처리하는 api 추가

## 💬리뷰 요구사항(선택)

## Issue Tags
> 아래 # 태그 뒤에 이슈 번호 붙여주세요!
- Closed: #200 
