### PR TITLE
[FEAT] Category API 연동

### DIFF
--- a/src/main/java/com/nhnacademy/illuwa/d_book/book/controller/AdminBookController.java
+++ b/src/main/java/com/nhnacademy/illuwa/d_book/book/controller/AdminBookController.java
@@ -1,5 +1,6 @@
 package com.nhnacademy.illuwa.d_book.book.controller;
 
+import com.nhnacademy.illuwa.d_book.book.dto.request.BookApiRegisterRequest;
 import jakarta.ws.rs.core.SecurityContext;
 import com.nhnacademy.illuwa.d_book.book.dto.request.BookRegisterRequest;
 import com.nhnacademy.illuwa.d_book.book.dto.request.BookUpdateRequest;
@@ -41,10 +42,18 @@ public class AdminBookController {
 
     }
 
-    // 외부 API 사용
+//    // 외부 API 사용
+//    @PostMapping("register/aladin")
+//    public ResponseEntity<BookDetailResponse> registerBook(@RequestBody @Valid BookRegisterRequest bookRegisterRequest){
+//        BookDetailResponse detailResponse = bookService.registerBook(bookRegisterRequest);
+//        return ResponseEntity.status(HttpStatus.CREATED).body(detailResponse);
+//    }
+
+    // 외부 API 사용 (front)
     @PostMapping("register/aladin")
-    public ResponseEntity<BookDetailResponse> registerBook(@RequestBody @Valid BookRegisterRequest bookRegisterRequest){
-        BookDetailResponse detailResponse = bookService.registerBook(bookRegisterRequest);
+    public ResponseEntity<BookDetailResponse> registerBook(@RequestBody @Valid BookApiRegisterRequest bookApiRegisterRequest){
+        // apiDTO -> bookRegisterDTO
+        BookDetailResponse detailResponse = bookService.registerBookByApi(bookApiRegisterRequest);
         return ResponseEntity.status(HttpStatus.CREATED).body(detailResponse);
     }
 

--- a/src/main/java/com/nhnacademy/illuwa/d_book/book/controller/AdminBookController.java
+++ b/src/main/java/com/nhnacademy/illuwa/d_book/book/controller/AdminBookController.java
@@ -1,5 +1,6 @@
 package com.nhnacademy.illuwa.d_book.book.controller;
 
+import jakarta.ws.rs.core.SecurityContext;
 import com.nhnacademy.illuwa.d_book.book.dto.request.BookRegisterRequest;
 import com.nhnacademy.illuwa.d_book.book.dto.request.BookUpdateRequest;
 import com.nhnacademy.illuwa.d_book.book.dto.request.FinalAladinBookRegisterRequest;

--- a/src/main/java/com/nhnacademy/illuwa/d_book/book/controller/BookController.java
+++ b/src/main/java/com/nhnacademy/illuwa/d_book/book/controller/BookController.java
@@ -3,6 +3,7 @@ package com.nhnacademy.illuwa.d_book.book.controller;
 import com.nhnacademy.illuwa.d_book.book.document.BookDocument;
 import com.nhnacademy.illuwa.d_book.book.dto.response.BestSellerResponse;
 import com.nhnacademy.illuwa.d_book.book.dto.response.BookDetailResponse;
+import com.nhnacademy.illuwa.d_book.book.dto.response.BookExternalResponse;
 import com.nhnacademy.illuwa.d_book.book.mapper.BookMapper;
 import com.nhnacademy.illuwa.d_book.book.service.BookService;
 import com.nhnacademy.illuwa.infra.apiclient.AladinBookApiService;
@@ -92,6 +93,17 @@ public class BookController {
     public ResponseEntity<BookDetailResponse> searchBookByIsbnInDB(@PathVariable String isbn){
         BookDetailResponse bookByIsbn = bookService.searchBookByIsbn(isbn);
         return ResponseEntity.ok(bookByIsbn);
+    }
+
+    @GetMapping("/external/isbn/{isbn}")
+    public ResponseEntity<BookExternalResponse> getBookByIsbnFromExternalApi(@PathVariable String isbn){
+        BookExternalResponse bookDetail = aladinBookApiService.findBookByIsbn(isbn);
+
+        if (bookDetail == null) {
+            return ResponseEntity.notFound().build();
+        }
+
+        return ResponseEntity.ok(bookDetail);
     }
 
 

--- a/src/main/java/com/nhnacademy/illuwa/d_book/book/dto/request/BookApiRegisterRequest.java
+++ b/src/main/java/com/nhnacademy/illuwa/d_book/book/dto/request/BookApiRegisterRequest.java
@@ -1,0 +1,26 @@
+package com.nhnacademy.illuwa.d_book.book.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class BookApiRegisterRequest {
+
+    private String title;
+    private String author;
+    private String publisher;
+    private String contents;
+    private String pubDate;
+    private String isbn;
+    private Integer regularPrice;
+    private Integer salePrice;
+    private String description;
+    private String cover; // hidden input으로 받은 이미지 URL
+    private int count;
+    private Long categoryId;
+}

--- a/src/main/java/com/nhnacademy/illuwa/d_book/book/mapper/BookMapper.java
+++ b/src/main/java/com/nhnacademy/illuwa/d_book/book/mapper/BookMapper.java
@@ -1,6 +1,7 @@
 package com.nhnacademy.illuwa.d_book.book.mapper;
 
 
+import com.nhnacademy.illuwa.d_book.book.dto.request.BookApiRegisterRequest;
 import com.nhnacademy.illuwa.d_book.book.dto.response.BookExternalResponse;
 import com.nhnacademy.illuwa.d_book.book.dto.request.BookRegisterRequest;
 import com.nhnacademy.illuwa.d_book.book.dto.request.FinalAladinBookRegisterRequest;
@@ -32,5 +33,13 @@ public interface BookMapper {
     @Mapping(source = "publisher", target = "publisher")
     @Mapping(source = "isbn", target = "isbn")
     Book fromFinalAladinRequest(FinalAladinBookRegisterRequest request);
+
+
+    @Mapping(source = "pubDate", target = "publishedDate")
+    @Mapping(source = "count", target = "bookExtraInfo.count")
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "bookImages", ignore = true)
+    @Mapping(target = "bookTags", ignore = true)
+    Book fromApiRequest(BookApiRegisterRequest request);
 
 }

--- a/src/main/java/com/nhnacademy/illuwa/d_book/category/controller/CategoryController.java
+++ b/src/main/java/com/nhnacademy/illuwa/d_book/category/controller/CategoryController.java
@@ -3,6 +3,7 @@ package com.nhnacademy.illuwa.d_book.category.controller;
 import com.nhnacademy.illuwa.d_book.category.dto.CategoryCreateRequest;
 import com.nhnacademy.illuwa.d_book.category.dto.CategoryResponse;
 import com.nhnacademy.illuwa.d_book.category.service.CategoryService;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.data.domain.Page;
@@ -35,14 +36,10 @@ public class CategoryController {
         return ResponseEntity.ok(categoryService.getCategoryInfo(categoryId));
     }
 
-    @PostMapping()
-    public ResponseEntity<CategoryResponse> registerCategory(@RequestBody CategoryCreateRequest categoryCreateRequest) {
-        CategoryResponse categoryResponse = categoryService.registerCategory(categoryCreateRequest);
-
-
-        URI location = URI.create("/categories/" + categoryResponse.getId());
-
-        return ResponseEntity.created(location).body(categoryResponse);
+    @PostMapping
+    public ResponseEntity<Void> createCategory(@RequestBody CategoryCreateRequest request) {
+        categoryService.createCategory(request);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
 
@@ -51,6 +48,15 @@ public class CategoryController {
         List<CategoryResponse> categoryTree = categoryService.getCategoryTree();
         return categoryTree;
     }
+
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteCategory(@PathVariable Long id) {
+        categoryService.deleteCategory(id);
+        return ResponseEntity.noContent().build();
+    }
+
+
 
 
 }

--- a/src/main/java/com/nhnacademy/illuwa/d_book/category/controller/CategoryController.java
+++ b/src/main/java/com/nhnacademy/illuwa/d_book/category/controller/CategoryController.java
@@ -45,4 +45,12 @@ public class CategoryController {
         return ResponseEntity.created(location).body(categoryResponse);
     }
 
+
+    @GetMapping("/tree")
+    public List<CategoryResponse> getCategoryTree() {
+        List<CategoryResponse> categoryTree = categoryService.getCategoryTree();
+        return categoryTree;
+    }
+
+
 }

--- a/src/main/java/com/nhnacademy/illuwa/d_book/category/dto/CategoryCreateRequest.java
+++ b/src/main/java/com/nhnacademy/illuwa/d_book/category/dto/CategoryCreateRequest.java
@@ -3,9 +3,11 @@ package com.nhnacademy.illuwa.d_book.category.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @AllArgsConstructor
+@NoArgsConstructor
 @Getter
 @Setter
 public class CategoryCreateRequest {

--- a/src/main/java/com/nhnacademy/illuwa/d_book/category/dto/CategoryResponse.java
+++ b/src/main/java/com/nhnacademy/illuwa/d_book/category/dto/CategoryResponse.java
@@ -1,21 +1,33 @@
 package com.nhnacademy.illuwa.d_book.category.dto;
 
 import com.nhnacademy.illuwa.d_book.category.entity.Category;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 
-@AllArgsConstructor
 @Getter
 @Setter
+@NoArgsConstructor
 public class CategoryResponse {
     private Long id;
-    private Long parentCategoryId;
-    private String CategoryName;
+    private Long parentId;
+    private String categoryName;
+    private List<CategoryResponse> children = new ArrayList<>();
 
-    public CategoryResponse(Category category){
+    public CategoryResponse(Category category) {
         this.id = category.getId();
-        this.parentCategoryId = category.getParentCategory().getId();
-        this.CategoryName = category.getCategoryName();
+        this.categoryName = category.getCategoryName();
+        if (category.getParentCategory() != null) {
+            this.parentId = category.getParentCategory().getId();
+        }
+
+        if (category.getChildrenCategory() != null) {
+            this.children = category.getChildrenCategory().stream()
+                    .map(CategoryResponse::new)
+                    .collect(Collectors.toList());
+        }
     }
 }

--- a/src/main/java/com/nhnacademy/illuwa/d_book/category/repository/category/CategoryRepository.java
+++ b/src/main/java/com/nhnacademy/illuwa/d_book/category/repository/category/CategoryRepository.java
@@ -3,5 +3,8 @@ package com.nhnacademy.illuwa.d_book.category.repository.category;
 import com.nhnacademy.illuwa.d_book.category.entity.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface CategoryRepository extends JpaRepository<Category, Long> , CustomizedCategoryRepository{
+    List<Category> findByParentCategoryIsNull();
 }

--- a/src/main/java/com/nhnacademy/illuwa/d_book/category/service/CategoryService.java
+++ b/src/main/java/com/nhnacademy/illuwa/d_book/category/service/CategoryService.java
@@ -76,11 +76,33 @@ public class CategoryService {
 
         parentCategory.addChildCategory(newCategory);
 
-
-
-
-
         return new CategoryResponse(newCategory);
     }
+
+    @Transactional
+    public void createCategory(CategoryCreateRequest request) {
+        Category newCategory = new Category(request.getCategoryName());
+
+        if (request.getParentId() != null) {
+            Category parent = categoryRepository.findById(request.getParentId())
+                    .orElseThrow(() -> new IllegalArgumentException("상위 카테고리가 존재하지 않습니다."));
+            parent.addChildCategory(newCategory);
+        }
+
+        categoryRepository.save(newCategory);
+    }
+
+    @Transactional
+    public void deleteCategory(Long categoryId) {
+        Category category = categoryRepository.findById(categoryId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 카테고리"));
+
+        if (!category.getChildrenCategory().isEmpty()) {
+            throw new IllegalStateException("하위 카테고리를 포함한 경우 삭제 불가");
+        }
+
+        categoryRepository.delete(category);
+    }
+
 
 }

--- a/src/test/java/com/nhnacademy/illuwa/d_book/category/service/CategoryServiceTest.java
+++ b/src/test/java/com/nhnacademy/illuwa/d_book/category/service/CategoryServiceTest.java
@@ -49,11 +49,11 @@ class CategoryServiceTest {
         CategoryResponse parentResponse = result.get(0);
         assertEquals(1L, parentResponse.getId());
         assertEquals("부모카테고리", parentResponse.getCategoryName());
-        assertNull(parentResponse.getParentCategoryId());
+        assertNull(parentResponse.getParentId());
 
         CategoryResponse childResponse = result.get(1);
         assertEquals(2L, childResponse.getId());
         assertEquals("자식카테고리", childResponse.getCategoryName());
-        assertEquals(1L, childResponse.getParentCategoryId());
+        assertEquals(1L, childResponse.getParentId());
     }
 }


### PR DESCRIPTION
## 📝작업 내용
- [x] 카테고리 관련
  - Category 계층 불러오는 API 추가  
  - Category Response DTO 수정  
  - root 계층의 카테고리 불러오는 API 추가  
  - Category REST API 핸들러 메서드 추가  
  - 카테고리 등록/삭제 API 추가  
  - 카테고리 생성 DTO 추가  
  - 카테고리 테스트코드 메서드 네이밍 변경  

- [x] 리팩토링
  - 불필요한 import / path 삭제  

- [x] 도서 등록 기능
  - API 활용한 도서 등록 추가  
  - API 활용한 도서 DTO 추가  
  - 외부 API 도서 검색(by ISBN) 엔드포인트 추가  
  - 도서 등록용 Mapper 추가  
  - API를 활용한 도서 등록 메서드 추가  

## 💬리뷰 요구사항(선택)

## Issue Tags
> 아래 # 태그 뒤에 이슈 번호 붙여주세요!
- Closed: #225 
