### PR TITLE
[FEAT] 카테고리 API 서비스 계층 및 DTO/Mapper 추가

### DIFF
--- a/src/main/java/com/nhnacademy/illuwa/d_book/category/controller/CategoryController.java
+++ b/src/main/java/com/nhnacademy/illuwa/d_book/category/controller/CategoryController.java
@@ -1,6 +1,7 @@
 package com.nhnacademy.illuwa.d_book.category.controller;
 
 import com.nhnacademy.illuwa.d_book.category.dto.CategoryCreateRequest;
+import com.nhnacademy.illuwa.d_book.category.dto.CategoryFlatResponse;
 import com.nhnacademy.illuwa.d_book.category.dto.CategoryResponse;
 import com.nhnacademy.illuwa.d_book.category.service.CategoryService;
 import org.springframework.http.HttpStatus;
@@ -55,6 +56,10 @@ public class CategoryController {
         return ResponseEntity.noContent().build();
     }
 
+    @GetMapping("/flat_paged")
+    public ResponseEntity<Page<CategoryFlatResponse>> getFlatCategoriesPaged(Pageable pageable) {
+        return ResponseEntity.ok(categoryService.getAllCategoriesFlatPaged(pageable));
+    }
 
 
 

--- a/src/main/java/com/nhnacademy/illuwa/d_book/category/dto/CategoryFlatResponse.java
+++ b/src/main/java/com/nhnacademy/illuwa/d_book/category/dto/CategoryFlatResponse.java
@@ -1,0 +1,20 @@
+package com.nhnacademy.illuwa.d_book.category.dto;
+
+import lombok.*;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class CategoryFlatResponse {
+    private Long id;
+    private Long parentId;
+    private String parentName;
+    private String categoryName;
+    private int depth;
+
+    public CategoryFlatResponse(Long id, Long parentId, String categoryName) {
+        this.id = id;
+        this.parentId = parentId;
+        this.categoryName = categoryName;
+    }
+}

--- a/src/main/java/com/nhnacademy/illuwa/d_book/category/dto/CategoryResponse.java
+++ b/src/main/java/com/nhnacademy/illuwa/d_book/category/dto/CategoryResponse.java
@@ -1,9 +1,8 @@
 package com.nhnacademy.illuwa.d_book.category.dto;
 
 import com.nhnacademy.illuwa.d_book.category.entity.Category;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -11,6 +10,8 @@ import java.util.stream.Collectors;
 @Getter
 @Setter
 @NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class CategoryResponse {
     private Long id;
     private Long parentId;
@@ -30,4 +31,14 @@ public class CategoryResponse {
                     .collect(Collectors.toList());
         }
     }
+
+    public static CategoryResponse fromEntity(Category category) {
+        return CategoryResponse.builder()
+                .id(category.getId())
+                .categoryName(category.getCategoryName())
+                .parentId(category.getParentCategory() != null ? category.getParentCategory().getId() : null)
+                .build();
+    }
+
+
 }


### PR DESCRIPTION
## 📝작업 내용
> 카테고리 API 기능을 확장하기 위해 다음 작업을 수행했습니다.

- 서비스 계층 메서드 추가
- Entity ↔ DTO 매핑 로직 보완
- FeignClient 통신용 DTO 생성
- 엔드포인트 경로 스네이크 케이스 적용

## 💬리뷰 요구사항(선택)

## Issue Tags
> 아래 # 태그 뒤에 이슈 번호 붙여주세요!
- Closed: #258 
