### PR TITLE
[REFACTOR] 외래키 제약조건 해결 - 카테고리 및 태그 삭제 로직 수정

### DIFF
--- a/src/main/java/com/nhnacademy/illuwa/d_book/category/repository/bookcategory/BookCategoryRepository.java
+++ b/src/main/java/com/nhnacademy/illuwa/d_book/category/repository/bookcategory/BookCategoryRepository.java
@@ -3,8 +3,10 @@ package com.nhnacademy.illuwa.d_book.category.repository.bookcategory;
 import com.nhnacademy.illuwa.d_book.category.entity.BookCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface BookCategoryRepository extends JpaRepository<BookCategory, Long>, CustomizedBookCategoryRepository {
     Optional<BookCategory> findByBookId(Long bookId);
+    List<BookCategory> findByCategoryId(Long categoryId);
 }

--- a/src/main/java/com/nhnacademy/illuwa/d_book/category/service/CategoryService.java
+++ b/src/main/java/com/nhnacademy/illuwa/d_book/category/service/CategoryService.java
@@ -3,8 +3,10 @@ package com.nhnacademy.illuwa.d_book.category.service;
 import com.nhnacademy.illuwa.d_book.category.dto.CategoryCreateRequest;
 import com.nhnacademy.illuwa.d_book.category.dto.CategoryFlatResponse;
 import com.nhnacademy.illuwa.d_book.category.dto.CategoryResponse;
+import com.nhnacademy.illuwa.d_book.category.entity.BookCategory;
 import com.nhnacademy.illuwa.d_book.category.entity.Category;
 import com.nhnacademy.illuwa.d_book.category.exception.CategoryNotAllowedException;
+import com.nhnacademy.illuwa.d_book.category.repository.bookcategory.BookCategoryRepository;
 import com.nhnacademy.illuwa.d_book.category.repository.category.CategoryRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,6 +27,7 @@ import java.util.stream.Collectors;
 public class CategoryService {
 
     private final CategoryRepository categoryRepository;
+    private final BookCategoryRepository bookCategoryRepository;
 
     public List<CategoryResponse> getAllCategories(){
         List<Category> categories = categoryRepository.findAll();
@@ -86,11 +89,18 @@ public class CategoryService {
 
     @Transactional
     public void deleteCategory(Long categoryId) {
+
         Category category = categoryRepository.findById(categoryId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 카테고리"));
 
         if (!category.getChildrenCategory().isEmpty()) {
             throw new IllegalStateException("하위 카테고리를 포함한 경우 삭제 불가");
+        }
+
+        List<BookCategory> bookCategories = bookCategoryRepository.findByCategoryId(categoryId);
+
+        if (!bookCategories.isEmpty()) {
+            bookCategoryRepository.deleteAll(bookCategories);
         }
 
         categoryRepository.delete(category);

--- a/src/main/java/com/nhnacademy/illuwa/d_book/tag/entity/Tag.java
+++ b/src/main/java/com/nhnacademy/illuwa/d_book/tag/entity/Tag.java
@@ -5,6 +5,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Setter
 @Getter
 @NoArgsConstructor
@@ -23,5 +26,6 @@ public class Tag {
     public Tag(String name){
         this.name = name;
     }
+
 
 }

--- a/src/main/java/com/nhnacademy/illuwa/d_book/tag/repository/BookTagRepository.java
+++ b/src/main/java/com/nhnacademy/illuwa/d_book/tag/repository/BookTagRepository.java
@@ -7,4 +7,5 @@ import java.util.List;
 
 public interface BookTagRepository extends JpaRepository<BookTag, Long> {
     List<BookTag> findByBookId(Long bookId);
+    List<BookTag> findByTagId(Long tagId);
 }

--- a/src/test/java/com/nhnacademy/illuwa/d_book/tag/service/TagServiceTest.java
+++ b/src/test/java/com/nhnacademy/illuwa/d_book/tag/service/TagServiceTest.java
@@ -2,28 +2,36 @@ package com.nhnacademy.illuwa.d_book.tag.service;
 
 import com.nhnacademy.illuwa.d_book.tag.dto.TagRegisterRequest;
 import com.nhnacademy.illuwa.d_book.tag.dto.TagResponse;
+import com.nhnacademy.illuwa.d_book.tag.entity.BookTag;
 import com.nhnacademy.illuwa.d_book.tag.entity.Tag;
+import com.nhnacademy.illuwa.d_book.tag.repository.BookTagRepository;
 import com.nhnacademy.illuwa.d_book.tag.repository.TagRepository;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class TagServiceTest {
 
     @Mock
     TagRepository tagRepository;
+
+    @Mock
+    BookTagRepository bookTagRepository;
+
 
     @InjectMocks
     TagService tagService;
@@ -51,13 +59,28 @@ class TagServiceTest {
     }
 
     @Test
+    @DisplayName("태그 삭제 - 성공")
     void deleteTag() {
-
         Long tagId = 11L;
+
+        Tag tag = new Tag();
+        tag.setId(tagId);
+        tag.setName("Test Tag");
+
+        List<BookTag> bookTags = List.of(
+                mock(BookTag.class),
+                mock(BookTag.class)
+        );
+
+        when(tagRepository.findById(tagId)).thenReturn(Optional.of(tag));
+
+        when(bookTagRepository.findByTagId(tagId)).thenReturn(bookTags);
 
         tagService.deleteTag(tagId);
 
-        verify(tagRepository).deleteById(tagId);
-
+        verify(tagRepository, times(1)).findById(tagId);
+        verify(bookTagRepository, times(1)).findByTagId(tagId);
+        verify(bookTagRepository, times(1)).deleteAll(bookTags);
+        verify(tagRepository, times(1)).delete(tag);
     }
 }


### PR DESCRIPTION
## 📝작업 내용

- **카테고리(Category) 삭제**
  - 기존에는 `@OneToMany(cascade = REMOVE, orphanRemoval = true)`를 사용했으나,
    FK 제약조건 충돌 발생
  - 서비스 계층에서 `book_category`에 해당하는 연관 데이터 직접 삭제 후 카테고리 삭제하는 방식으로 변경

- **태그(Tag) 삭제**
  - 동일하게 `book_tag` 테이블에서 해당 태그에 매핑된 데이터 선 삭제 후 태그 삭제 처리

## 💬리뷰 요구사항(선택)

## Issue Tags
> 아래 # 태그 뒤에 이슈 번호 붙여주세요!
- Closed: #267 
