### PR TITLE
[FEAT] 카테고리별 도서 조회 API

### DIFF
--- a/src/main/java/com/nhnacademy/illuwa/d_book/book/controller/BookController.java
+++ b/src/main/java/com/nhnacademy/illuwa/d_book/book/controller/BookController.java
@@ -119,8 +119,8 @@ public class BookController {
         return ResponseEntity.ok(results);
     }
 
-    @GetMapping("/search/by-category-name")
-    public ResponseEntity<List<BookOrderResponse>> getBooksByCategoryName(@RequestParam("name") String categoryName) {
+    @GetMapping("/by-category")
+    public ResponseEntity<List<BookOrderResponse>> getBooksByCategoryName(@RequestParam("categoryName") String categoryName) {
         List<Book> books = bookService.findBooksByCategoryAndSubCategories(categoryName);
 
         List<BookOrderResponse> response = books.stream()

--- a/src/main/java/com/nhnacademy/illuwa/d_book/book/controller/BookController.java
+++ b/src/main/java/com/nhnacademy/illuwa/d_book/book/controller/BookController.java
@@ -4,6 +4,8 @@ import com.nhnacademy.illuwa.d_book.book.document.BookDocument;
 import com.nhnacademy.illuwa.d_book.book.dto.response.BestSellerResponse;
 import com.nhnacademy.illuwa.d_book.book.dto.response.BookDetailResponse;
 import com.nhnacademy.illuwa.d_book.book.dto.response.BookExternalResponse;
+import com.nhnacademy.illuwa.d_book.book.dto.response.BookOrderResponse;
+import com.nhnacademy.illuwa.d_book.book.entity.Book;
 import com.nhnacademy.illuwa.d_book.book.mapper.BookMapper;
 import com.nhnacademy.illuwa.d_book.book.service.BookService;
 import com.nhnacademy.illuwa.infra.apiclient.AladinBookApiService;
@@ -19,6 +21,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Tag(name = "📖 도서 API", description = "도서 조회 및 검색 관련 API")
 @RestController
@@ -114,6 +117,17 @@ public class BookController {
 
         Page<BookDocument> results = bookService.searchByKeyword(keyword, pageable);
         return ResponseEntity.ok(results);
+    }
+
+    @GetMapping("/search/by-category-name")
+    public ResponseEntity<List<BookOrderResponse>> getBooksByCategoryName(@RequestParam("name") String categoryName) {
+        List<Book> books = bookService.findBooksByCategoryAndSubCategories(categoryName);
+
+        List<BookOrderResponse> response = books.stream()
+                .map(BookOrderResponse::fromEntity)
+                .collect(Collectors.toList());
+
+        return ResponseEntity.ok(response);
     }
 
 

--- a/src/main/java/com/nhnacademy/illuwa/d_book/book/dto/response/BookOrderResponse.java
+++ b/src/main/java/com/nhnacademy/illuwa/d_book/book/dto/response/BookOrderResponse.java
@@ -1,0 +1,44 @@
+package com.nhnacademy.illuwa.d_book.book.dto.response;
+
+import com.nhnacademy.illuwa.d_book.book.entity.Book;
+import com.nhnacademy.illuwa.d_book.book.enums.Status;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+@Getter
+@Builder
+public class BookOrderResponse {
+
+    private Long id;
+    private String title;
+    private String author;
+    private BigDecimal salePrice;
+
+    private Integer stockCount; // 재고 수량
+    private String status;      // 판매 상태 (e.g., "FOR_SALE", "SOLD_OUT")
+    private boolean isGiftWrapAvailable; // 포장 가능 여부
+
+    public static BookOrderResponse fromEntity(Book book) {
+        Integer stockCount = 0;
+        String status = Status.NORMAL.toString();
+        boolean isGiftWrapAvailable = false;
+
+        if (book.getBookExtraInfo() != null) {
+            stockCount = book.getBookExtraInfo().getCount();
+            status = book.getBookExtraInfo().getStatus().name();
+            isGiftWrapAvailable = book.getBookExtraInfo().isGiftwrap();
+        }
+
+        return BookOrderResponse.builder()
+                .id(book.getId())
+                .title(book.getTitle())
+                .author(book.getAuthor())
+                .salePrice(book.getSalePrice())
+                .stockCount(stockCount)
+                .status(status)
+                .isGiftWrapAvailable(isGiftWrapAvailable)
+                .build();
+    }
+}

--- a/src/main/java/com/nhnacademy/illuwa/d_book/book/repository/BookRepositoryCustom.java
+++ b/src/main/java/com/nhnacademy/illuwa/d_book/book/repository/BookRepositoryCustom.java
@@ -4,9 +4,13 @@ import com.nhnacademy.illuwa.d_book.book.entity.Book;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
+
 public interface BookRepositoryCustom {
 
     Page<Book> findBooksByCriteria(Long categoryId, String tagName, Pageable pageable);
 
     void deleteBookAndRelatedEntities(Long bookId);
+
+    List<Book> findBooksByCategories(List<Long> categoryIds);
 }

--- a/src/main/java/com/nhnacademy/illuwa/d_book/book/repository/BookRepositoryCustomImpl.java
+++ b/src/main/java/com/nhnacademy/illuwa/d_book/book/repository/BookRepositoryCustomImpl.java
@@ -131,4 +131,23 @@ public class BookRepositoryCustomImpl implements BookRepositoryCustom {
                 .where(book.id.eq(bookId))
                 .execute();
     }
+
+    @Override
+    public List<Book> findBooksByCategories(List<Long> categoryIds) {
+
+        QBook book = QBook.book;
+        QBookCategory bookCategory = QBookCategory.bookCategory;
+
+        return queryFactory
+                // SELECT b
+                .select(bookCategory.book)
+                // FROM BookCategory bc
+                .from(bookCategory)
+                // JOIN bc.book b (BookCategory 엔티티의 book 필드를 통해 Book 엔티티와 조인)
+                .join(bookCategory.book, book)
+                // WHERE bc.category.id IN :categoryIds
+                .where(bookCategory.category.id.in(categoryIds))
+                .distinct() // 중복된 책이 조회될 수 있으므로 distinct() 추가
+                .fetch();
+    }
 }

--- a/src/main/java/com/nhnacademy/illuwa/d_book/book/service/BookService.java
+++ b/src/main/java/com/nhnacademy/illuwa/d_book/book/service/BookService.java
@@ -41,9 +41,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
@@ -445,6 +443,30 @@ public class BookService {
         }
 
 
+    }
+
+    @Transactional(readOnly = true)
+    public List<Book> findBooksByCategoryAndSubCategories(String categoryName) {
+
+        Category parentCategory = categoryRepository.findByCategoryName(categoryName)
+                .orElseThrow(() -> new IllegalArgumentException("해당 카테고리를 찾을 수 없습니다: " + categoryName));
+
+
+        List<Long> allCategoryIds = new ArrayList<>();
+        Queue<Category> categoriesToVisit = new LinkedList<>();
+
+        categoriesToVisit.add(parentCategory);
+
+        while (!categoriesToVisit.isEmpty()) {
+
+            Category currentCategory = categoriesToVisit.poll();
+            allCategoryIds.add(currentCategory.getId());
+            if (currentCategory.getChildrenCategory() != null) {
+                categoriesToVisit.addAll(currentCategory.getChildrenCategory());
+            }
+        }
+
+        return bookRepository.findBooksByCategories(allCategoryIds);
     }
 
 

--- a/src/main/java/com/nhnacademy/illuwa/d_book/category/repository/category/CategoryRepository.java
+++ b/src/main/java/com/nhnacademy/illuwa/d_book/category/repository/category/CategoryRepository.java
@@ -4,7 +4,10 @@ import com.nhnacademy.illuwa.d_book.category.entity.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> , CustomizedCategoryRepository{
     List<Category> findByParentCategoryIsNull();
+
+    Optional<Category> findByCategoryName(String categoryName);
 }


### PR DESCRIPTION
## 📝작업 내용
특정 카테고리 이름을 입력받아, 그 카테고리뿐만 아니라 모든 하위 계층의 카테고리에 속한 도서 목록까지 함께 조회하여 반환하는 api 추가

예: 'IT' 카테고리 조회 시, 하위 카테고리인 '프로그래밍 언어', '네트워크' 등에 속한 책들도 모두 포함하여 응답



## 💬리뷰 요구사항(선택)
- api로 테스트해서 반환값 확인해보고 활용여부 mention으로 남겨주세요
- DTO는 custom으로 수정해서 활용하시면 됩니다
- http://localhost:10307/api/books/by-category?categoryName=소설 (Test)

## Issue Tags
> 아래 # 태그 뒤에 이슈 번호 붙여주세요!
- Closed: #270 
