### PR TITLE
[FEAT] 도서 수량 업데이트 api 추가 

### DIFF
--- a/src/main/java/com/nhnacademy/illuwa/cart/dto/BookCountUpdateRequest.java
+++ b/src/main/java/com/nhnacademy/illuwa/cart/dto/BookCountUpdateRequest.java
@@ -1,0 +1,13 @@
+package com.nhnacademy.illuwa.cart.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class BookCountUpdateRequest {
+    private Long bookId;
+    private Integer bookCount;
+}

--- a/src/main/java/com/nhnacademy/illuwa/d_book/book/controller/AdminBookController.java
+++ b/src/main/java/com/nhnacademy/illuwa/d_book/book/controller/AdminBookController.java
@@ -1,5 +1,6 @@
 package com.nhnacademy.illuwa.d_book.book.controller;
 
+import com.nhnacademy.illuwa.cart.dto.BookCountUpdateRequest;
 import com.nhnacademy.illuwa.d_book.book.dto.request.BookApiRegisterRequest;
 import com.nhnacademy.illuwa.d_book.book.dto.response.BookDetailWithExtraInfoResponse;
 import com.nhnacademy.illuwa.d_book.book.dto.request.BookRegisterRequest;
@@ -94,6 +95,16 @@ public class AdminBookController {
         Page<BookDetailWithExtraInfoResponse> response = bookService.getAllBooksWithExtraInfo(pageable);
 
         return ResponseEntity.ok(response);
+    }
+
+
+
+    @PatchMapping("/update/bookCount")
+    public ResponseEntity<Void> deductBooksCount(
+            @RequestBody List<BookCountUpdateRequest> requests
+    ) {
+        bookService.updateBooksCount(requests);
+        return ResponseEntity.noContent().build();
     }
 
 

--- a/src/main/java/com/nhnacademy/illuwa/d_book/book/service/BookService.java
+++ b/src/main/java/com/nhnacademy/illuwa/d_book/book/service/BookService.java
@@ -1,5 +1,6 @@
 package com.nhnacademy.illuwa.d_book.book.service;
 
+import com.nhnacademy.illuwa.cart.dto.BookCountUpdateRequest;
 import com.nhnacademy.illuwa.d_book.book.dto.request.BookApiRegisterRequest;
 import com.nhnacademy.illuwa.d_book.book.dto.request.BookRegisterRequest;
 import com.nhnacademy.illuwa.d_book.book.dto.request.BookUpdateRequest;
@@ -467,6 +468,28 @@ public class BookService {
         }
 
         return bookRepository.findBooksByCategories(allCategoryIds);
+    }
+
+    @Transactional
+    public void updateBooksCount(List<BookCountUpdateRequest> requests) {
+        for (BookCountUpdateRequest request : requests) {
+            Book book = bookRepository.findById(request.getBookId())
+                    .orElseThrow(() -> new NotFoundBookException("ID " + request.getBookId() + "에 해당하는 도서를 찾을 수 없습니다."));
+
+            if (book.getBookExtraInfo() == null) {
+                throw new IllegalStateException("도서에 부가 정보가 존재하지 않습니다.");
+            }
+
+            int currentCount = Optional.ofNullable(book.getBookExtraInfo().getCount()).orElse(0);
+
+            int updatedCount = currentCount - request.getBookCount();
+
+            if (updatedCount < 0) {
+                throw new IllegalArgumentException("재고 부족: 현재 재고=" + currentCount + ", 요청 차감=" + request.getBookCount());
+            }
+
+            book.getBookExtraInfo().setCount(updatedCount);
+        }
     }
 
 


### PR DESCRIPTION
## 📝작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명
-  도서 수량 업데이트 api 추가
- request dto ( 도서 id, 차감할 도서 수량 ) 
`List<BookCountUpdateRequest>`
- endpoint 추가
`http://localhost:10307/api/admin/books/update/bookCount`

## 💬리뷰 요구사항(선택)
- 우선 postman으로 빠르게 테스트했습니다.

## Issue Tags
> 아래 # 태그 뒤에 이슈 번호 붙여주세요!
- Closed: #280 
