### PR TITLE
Refactor/book search refactoring

### DIFF
--- a/src/main/java/com/nhnacademy/illuwa/d_book/book/controller/BookController.java
+++ b/src/main/java/com/nhnacademy/illuwa/d_book/book/controller/BookController.java
@@ -1,11 +1,8 @@
 package com.nhnacademy.illuwa.d_book.book.controller;
 
-import com.nhnacademy.illuwa.search.document.BookDocument;
 import com.nhnacademy.illuwa.d_book.book.dto.response.BestSellerResponse;
 import com.nhnacademy.illuwa.d_book.book.dto.response.BookDetailResponse;
 import com.nhnacademy.illuwa.d_book.book.dto.response.BookExternalResponse;
-import com.nhnacademy.illuwa.d_book.book.dto.response.BookOrderResponse;
-import com.nhnacademy.illuwa.d_book.book.entity.Book;
 import com.nhnacademy.illuwa.d_book.book.mapper.BookMapper;
 import com.nhnacademy.illuwa.d_book.book.service.BookService;
 import com.nhnacademy.illuwa.infra.apiclient.AladinBookApiService;
@@ -22,7 +19,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Tag(name = "도서 API", description = "도서 조회 및 검색 관련 API")
 @RestController
@@ -110,27 +106,6 @@ public class BookController {
         }
 
         return ResponseEntity.ok(bookDetail);
-    }
-
-
-    @GetMapping("/search/es")
-    public ResponseEntity<Page<BookDocument>> searchBooksByKeyword(
-            @RequestParam String keyword,
-            Pageable pageable) {
-
-        Page<BookDocument> results = bookService.searchByKeyword(keyword, pageable);
-        return ResponseEntity.ok(results);
-    }
-
-    @GetMapping("/by-category")
-    public ResponseEntity<List<BookOrderResponse>> getBooksByCategoryName(@RequestParam("categoryName") String categoryName) {
-        List<Book> books = bookService.findBooksByCategoryAndSubCategories(categoryName);
-
-        List<BookOrderResponse> response = books.stream()
-                .map(BookOrderResponse::fromEntity)
-                .collect(Collectors.toList());
-
-        return ResponseEntity.ok(response);
     }
 
 

--- a/src/main/java/com/nhnacademy/illuwa/d_book/book/controller/BookController.java
+++ b/src/main/java/com/nhnacademy/illuwa/d_book/book/controller/BookController.java
@@ -1,12 +1,13 @@
 package com.nhnacademy.illuwa.d_book.book.controller;
 
-import com.nhnacademy.illuwa.d_book.book.document.BookDocument;
+import com.nhnacademy.illuwa.search.document.BookDocument;
 import com.nhnacademy.illuwa.d_book.book.dto.response.BestSellerResponse;
 import com.nhnacademy.illuwa.d_book.book.dto.response.BookDetailResponse;
 import com.nhnacademy.illuwa.d_book.book.dto.response.BookExternalResponse;
 import com.nhnacademy.illuwa.d_book.book.mapper.BookMapper;
 import com.nhnacademy.illuwa.d_book.book.service.BookService;
 import com.nhnacademy.illuwa.infra.apiclient.AladinBookApiService;
+import com.nhnacademy.illuwa.search.service.BookSearchService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -25,14 +26,16 @@ import java.util.List;
 @RequestMapping("/api/books")
 public class BookController {
 
+    private final BookSearchService bookSearchService;
     BookService bookService;
     AladinBookApiService aladinBookApiService;
     BookMapper bookMapper;
 
-    BookController(BookService bookService, AladinBookApiService aladinBookApiService, BookMapper bookMapper){
+    BookController(BookService bookService, AladinBookApiService aladinBookApiService, BookMapper bookMapper, BookSearchService bookSearchService){
         this.bookService = bookService;
         this.aladinBookApiService = aladinBookApiService;
         this.bookMapper = bookMapper;
+        this.bookSearchService = bookSearchService;
     }
 
     @Operation(summary = "도서 제목으로 검색", description = "DB에 저장된 도서를 제목(일부 포함)으로 검색")
@@ -104,16 +107,6 @@ public class BookController {
         }
 
         return ResponseEntity.ok(bookDetail);
-    }
-
-
-    @GetMapping("/search/es")
-    public ResponseEntity<Page<BookDocument>> searchBooksByKeyword(
-            @RequestParam String keyword,
-            Pageable pageable) {
-
-        Page<BookDocument> results = bookService.searchByKeyword(keyword, pageable);
-        return ResponseEntity.ok(results);
     }
 
 

--- a/src/main/java/com/nhnacademy/illuwa/d_book/book/controller/BookController.java
+++ b/src/main/java/com/nhnacademy/illuwa/d_book/book/controller/BookController.java
@@ -21,15 +21,15 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-@Tag(name = "📖 도서 API", description = "도서 조회 및 검색 관련 API")
+@Tag(name = "도서 API", description = "도서 조회 및 검색 관련 API")
 @RestController
 @RequestMapping("/api/books")
 public class BookController {
 
     private final BookSearchService bookSearchService;
-    BookService bookService;
-    AladinBookApiService aladinBookApiService;
-    BookMapper bookMapper;
+    private final BookService bookService;
+    private final AladinBookApiService aladinBookApiService;
+    private final BookMapper bookMapper;
 
     BookController(BookService bookService, AladinBookApiService aladinBookApiService, BookMapper bookMapper, BookSearchService bookSearchService){
         this.bookService = bookService;

--- a/src/main/java/com/nhnacademy/illuwa/d_book/book/repository/BookSearchRepository.java
+++ b/src/main/java/com/nhnacademy/illuwa/d_book/book/repository/BookSearchRepository.java
@@ -1,8 +1,0 @@
-package com.nhnacademy.illuwa.d_book.book.repository;
-
-
-import com.nhnacademy.illuwa.d_book.book.document.BookDocument;
-import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
-
-public interface BookSearchRepository extends ElasticsearchRepository<BookDocument, Long> {
-}

--- a/src/main/java/com/nhnacademy/illuwa/d_book/book/service/BookService.java
+++ b/src/main/java/com/nhnacademy/illuwa/d_book/book/service/BookService.java
@@ -26,17 +26,10 @@ import com.nhnacademy.illuwa.d_book.tag.repository.BookTagRepository;
 import com.nhnacademy.illuwa.d_book.tag.repository.TagRepository;
 import com.nhnacademy.illuwa.infra.apiclient.AladinBookApiService;
 import com.nhnacademy.illuwa.infra.storage.MinioStorageService;
+import com.nhnacademy.illuwa.search.service.BookSearchService;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import lombok.extern.slf4j.Slf4j;
-import com.nhnacademy.illuwa.d_book.book.document.BookDocument;
-import com.nhnacademy.illuwa.d_book.book.repository.BookSearchRepository;
-import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
-import org.springframework.data.elasticsearch.core.SearchHit;
-import org.springframework.data.elasticsearch.core.SearchHits;
-import org.springframework.data.elasticsearch.core.query.Query;
-import org.springframework.data.elasticsearch.core.query.StringQuery;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -44,7 +37,6 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 @Service
 @Slf4j
@@ -58,12 +50,11 @@ public class BookService {
     private final CategoryRepository categoryRepository;
     private final BookCategoryRepository bookCategoryRepository;
     private final MinioStorageService minioStorageService;
-    private final BookSearchRepository bookSearchRepository;
-    private final ElasticsearchOperations elasticsearchOperations;
+    private final BookSearchService bookSearchService;
 
 
 
-    public BookService(AladinBookApiService aladinBookApiService, BookRepository bookRepository, BookResponseMapper bookResponseMapper, TagRepository tagRepository, BookTagRepository bookTagRepository, BookImageRepository bookImageRepository, BookMapper bookMapper, CategoryRepository categoryRepository, BookCategoryRepository bookCategoryRepository, MinioStorageService minioStorageService, BookSearchRepository bookSearchRepository, ElasticsearchOperations elasticsearchOperations) {
+    public BookService(AladinBookApiService aladinBookApiService, BookRepository bookRepository, BookResponseMapper bookResponseMapper, TagRepository tagRepository, BookTagRepository bookTagRepository, BookImageRepository bookImageRepository, BookMapper bookMapper, CategoryRepository categoryRepository, BookCategoryRepository bookCategoryRepository, MinioStorageService minioStorageService, BookSearchService bookSearchService) {
         this.aladinBookApiService = aladinBookApiService;
         this.bookRepository = bookRepository;
         this.bookResponseMapper = bookResponseMapper;
@@ -73,8 +64,7 @@ public class BookService {
         this.categoryRepository = categoryRepository;
         this.bookCategoryRepository = bookCategoryRepository;
         this.minioStorageService = minioStorageService;
-        this.bookSearchRepository = bookSearchRepository;
-        this.elasticsearchOperations = elasticsearchOperations;
+        this.bookSearchService = bookSearchService;
     }
 
     // 외부 API에서 도서 검색
@@ -94,7 +84,7 @@ public class BookService {
         Optional<Book> book = bookRepository.findById(id);
 
         if (book.isEmpty()) {
-            throw new NotFoundBookException("제목과 일치하는 도서가 존재하지 않습니다.");
+            throw new NotFoundBookException("해당 ID(" + id + ")의 도서가 존재하지 않습니다.");
         }
 
         Book bookEntity = book.get();
@@ -110,7 +100,7 @@ public class BookService {
         Optional<Book> book = bookRepository.findByIsbn(isbn);
 
         if (book.isEmpty()) {
-            throw new NotFoundBookException("제목과 일치하는 도서가 존재하지 않습니다.");
+            throw new NotFoundBookException("해당 isbn(" + isbn + ")의 도서가 존재하지 않습니다.");
         }
 
         Book bookEntity = book.get();
@@ -265,7 +255,7 @@ public class BookService {
 
         Book savedBook = bookRepository.save(bookEntity);
         bookImageRepository.save(bookImage);
-        syncBookToElasticsearch(savedBook);
+        bookSearchService.syncBookToElasticsearch(savedBook);
 
         return bookResponseMapper.toBookDetailResponse(bookEntity);
     }
@@ -312,7 +302,7 @@ public class BookService {
 
         bookCategoryRepository.save(new BookCategory(savedBook,categoryEntity));
 
-        syncBookToElasticsearch(savedBook);
+        bookSearchService.syncBookToElasticsearch(savedBook);
 
 
         return bookResponseMapper.toBookDetailResponse(bookEntity); // Entity -> DTO
@@ -329,7 +319,7 @@ public class BookService {
             throw new NotFoundBookException("id : " + id + "에 해당하는 도서를 찾을 수 없습니다.");
         }
 
-        bookSearchRepository.deleteById(id);
+        bookSearchService.deleteById(id);
 
         Book targetBook = book.get();
         bookRepository.delete(targetBook);
@@ -343,46 +333,6 @@ public class BookService {
         bookRepository.deleteBookAndRelatedEntities(bookId);
     }
 
-    // 엘라스틱서치에 동기화
-    private void syncBookToElasticsearch(Book book) {
-        BookDocument bookDocument = BookDocument.builder()
-                .id(book.getId())
-                .title(book.getTitle())
-                .description(book.getDescription())
-                .author(book.getAuthor())
-                .publisher(book.getPublisher())
-                .isbn(book.getIsbn())
-                .salePrice(book.getSalePrice())
-                .thumbnailUrl(book.getBookImages() != null && !book.getBookImages().isEmpty() ? book.getBookImages().get(0).getImageUrl() : null)
-                .build();
-        bookSearchRepository.save(bookDocument);
-    }
-
-
-    // 키워드로 엘라스틱서치 검색
-    @Transactional(readOnly = true)
-    public Page<BookDocument> searchByKeyword(String keyword, Pageable pageable) {
-
-        String[] searchFields = {"title", "description", "author"};
-
-        Query query = new StringQuery(
-                String.format("{\"multi_match\": {\"query\": \"%s\", \"fields\": [\"%s\"]}}",
-                        keyword,
-                        String.join("\", \"", searchFields))
-        );
-        query.setPageable(pageable);
-
-        SearchHits<BookDocument> searchHits = elasticsearchOperations.search(query, BookDocument.class);
-
-        List<BookDocument> content = searchHits.getSearchHits().stream()
-                .map(SearchHit::getContent)
-                .collect(Collectors.toList());
-
-        // 5. 최종 결과를 Page 객체로 포장해서 Controller에게 돌려줌
-        return new PageImpl<>(content, pageable, searchHits.getTotalHits());
-    }
-
-
 
 
     // 도서 수정
@@ -390,7 +340,7 @@ public class BookService {
     public void updateBook(Long id, BookUpdateRequest requestDto) {
         Optional<Book> bookById = bookRepository.findById(id);
         if (bookById.isEmpty()) {
-            throw new NotFoundBookException("해당 도서를 찾을 수 없습니다. id: " + id);
+            throw new NotFoundBookException("해당 ID(" + id + ")의 도서가 존재하지 않습니다.");
         }
 
         Book book = bookById.get();
@@ -443,6 +393,8 @@ public class BookService {
 
             bookImage.setImageUrl(requestDto.getCover());
         }
+
+        bookSearchService.syncBookToElasticsearch(book);
 
 
     }

--- a/src/main/java/com/nhnacademy/illuwa/search/controller/BookSearchController.java
+++ b/src/main/java/com/nhnacademy/illuwa/search/controller/BookSearchController.java
@@ -10,16 +10,12 @@ import org.springframework.web.bind.annotation.*;
 
 //@CrossOrigin
 @RestController
-@RequestMapping("/api/search")
+@RequestMapping("/api/books/search")
 @RequiredArgsConstructor
 public class BookSearchController {
 
     private final BookSearchService bookSearchService;
 
-    /**
-     * 키워드로 도서 검색
-     * ex) GET /api/search?keyword=소설
-     */
     @GetMapping
     public ResponseEntity<Page<BookDocument>> searchBooksByKeyword(
             @RequestParam String keyword,
@@ -29,20 +25,12 @@ public class BookSearchController {
         return ResponseEntity.ok(results);
     }
 
-    /**
-     * 색인 추가 또는 갱신
-     * ex) POST /api/search/index
-     */
     @PostMapping("/index")
     public ResponseEntity<Void> indexBook(@RequestBody BookDocument bookDocument) {
         bookSearchService.save(bookDocument);
         return ResponseEntity.ok().build();
     }
 
-    /**
-     * 색인 삭제
-     * ex) DELETE /api/search/index/{id}
-     */
     @DeleteMapping("/index/{id}")
     public ResponseEntity<Void> deleteIndex(@PathVariable Long id) {
         bookSearchService.deleteById(id);

--- a/src/main/java/com/nhnacademy/illuwa/search/controller/BookSearchController.java
+++ b/src/main/java/com/nhnacademy/illuwa/search/controller/BookSearchController.java
@@ -1,0 +1,51 @@
+package com.nhnacademy.illuwa.search.controller;
+
+import com.nhnacademy.illuwa.search.document.BookDocument;
+import com.nhnacademy.illuwa.search.service.BookSearchService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+//@CrossOrigin
+@RestController
+@RequestMapping("/api/search")
+@RequiredArgsConstructor
+public class BookSearchController {
+
+    private final BookSearchService bookSearchService;
+
+    /**
+     * 키워드로 도서 검색
+     * ex) GET /api/search?keyword=소설
+     */
+    @GetMapping
+    public ResponseEntity<Page<BookDocument>> searchBooksByKeyword(
+            @RequestParam String keyword,
+            Pageable pageable
+    ) {
+        Page<BookDocument> results = bookSearchService.searchByKeyword(keyword, pageable);
+        return ResponseEntity.ok(results);
+    }
+
+    /**
+     * 색인 추가 또는 갱신
+     * ex) POST /api/search/index
+     */
+    @PostMapping("/index")
+    public ResponseEntity<Void> indexBook(@RequestBody BookDocument bookDocument) {
+        bookSearchService.save(bookDocument);
+        return ResponseEntity.ok().build();
+    }
+
+    /**
+     * 색인 삭제
+     * ex) DELETE /api/search/index/{id}
+     */
+    @DeleteMapping("/index/{id}")
+    public ResponseEntity<Void> deleteIndex(@PathVariable Long id) {
+        bookSearchService.deleteById(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/nhnacademy/illuwa/search/controller/BookSearchController.java
+++ b/src/main/java/com/nhnacademy/illuwa/search/controller/BookSearchController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.*;
 
 //@CrossOrigin
 @RestController
-@RequestMapping("/api/books/search")
+@RequestMapping("/api/search")
 @RequiredArgsConstructor
 public class BookSearchController {
 
@@ -35,5 +35,11 @@ public class BookSearchController {
     public ResponseEntity<Void> deleteIndex(@PathVariable Long id) {
         bookSearchService.deleteById(id);
         return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/index/sync")
+    public ResponseEntity<Void> syncAllBooks() {
+        bookSearchService.syncAllBooksToElasticsearch();
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/nhnacademy/illuwa/search/document/BookDocument.java
+++ b/src/main/java/com/nhnacademy/illuwa/search/document/BookDocument.java
@@ -12,7 +12,7 @@ import org.springframework.data.elasticsearch.annotations.Setting;
 
 import java.math.BigDecimal;
 
-@Document(indexName = "books-v1")
+@Document(indexName = "books-v2")
 @Setting(settingPath = "elasticsearch/nori-settings.json")
 @Getter
 @Builder

--- a/src/main/java/com/nhnacademy/illuwa/search/document/BookDocument.java
+++ b/src/main/java/com/nhnacademy/illuwa/search/document/BookDocument.java
@@ -1,4 +1,4 @@
-package com.nhnacademy.illuwa.d_book.book.document;
+package com.nhnacademy.illuwa.search.document;
 
 import jakarta.persistence.Id;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/nhnacademy/illuwa/search/repository/BookSearchRepository.java
+++ b/src/main/java/com/nhnacademy/illuwa/search/repository/BookSearchRepository.java
@@ -1,0 +1,13 @@
+package com.nhnacademy.illuwa.search.repository;
+
+
+import com.nhnacademy.illuwa.search.document.BookDocument;
+import org.springframework.data.domain.Page;
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+import org.springframework.data.domain.Pageable;
+
+
+public interface BookSearchRepository extends ElasticsearchRepository<BookDocument, Long> {
+
+    Page<BookDocument> findByTitleContainingOrAuthorContainingOrDescriptionContaining(String title, String author, String description, Pageable pageable);
+}

--- a/src/main/java/com/nhnacademy/illuwa/search/service/BookSearchService.java
+++ b/src/main/java/com/nhnacademy/illuwa/search/service/BookSearchService.java
@@ -1,0 +1,90 @@
+package com.nhnacademy.illuwa.search.service;
+
+
+import com.nhnacademy.illuwa.d_book.book.entity.Book;
+import com.nhnacademy.illuwa.search.document.BookDocument;
+import com.nhnacademy.illuwa.search.repository.BookSearchRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.SearchHit;
+import org.springframework.data.elasticsearch.core.SearchHits;
+import org.springframework.data.elasticsearch.core.query.Query;
+import org.springframework.data.elasticsearch.core.query.StringQuery;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@Slf4j
+public class BookSearchService {
+
+    private final BookSearchRepository bookSearchRepository;
+    private final ElasticsearchOperations elasticsearchOperations;
+
+    public BookSearchService(BookSearchRepository bookSearchRepository, ElasticsearchOperations elasticsearchOperations) {
+        this.bookSearchRepository = bookSearchRepository;
+        this.elasticsearchOperations = elasticsearchOperations;
+    }
+
+
+    public Page<BookDocument> searchByManyKeyword(String keyword, Pageable pageable) {
+        return bookSearchRepository
+                .findByTitleContainingOrAuthorContainingOrDescriptionContaining(keyword, keyword, keyword, pageable);
+    }
+
+    public Page<BookDocument> searchByKeyword(String keyword, Pageable pageable) {
+        String[] searchFields = {"title", "description", "author"};
+
+        Query query = new StringQuery(
+                String.format(
+                        "{\"multi_match\": {\"query\": \"%s\", \"fields\": [\"%s\"]}}",
+                        keyword,
+                        String.join("\", \"", searchFields)
+                )
+        );
+        query.setPageable(pageable);
+
+        SearchHits<BookDocument> searchHits = elasticsearchOperations.search(query, BookDocument.class);
+
+        List<BookDocument> content = searchHits.getSearchHits().stream()
+                .map(SearchHit::getContent)
+                .collect(Collectors.toList());
+
+        return new PageImpl<>(content, pageable, searchHits.getTotalHits());
+    }
+
+
+    public void syncBookToElasticsearch(Book book) {
+        BookDocument bookDocument = BookDocument.builder()
+                .id(book.getId())
+                .title(book.getTitle())
+                .description(book.getDescription())
+                .author(book.getAuthor())
+                .publisher(book.getPublisher())
+                .isbn(book.getIsbn())
+                .salePrice(book.getSalePrice())
+                .thumbnailUrl(
+                        book.getBookImages() != null && !book.getBookImages().isEmpty()
+                                ? book.getBookImages().get(0).getImageUrl()
+                                : null
+                )
+                .build();
+
+        bookSearchRepository.save(bookDocument);
+        log.info("Elasticsearch에 동기화 완료: id={}", book.getId());
+    }
+
+
+    public void save(BookDocument document) {
+        bookSearchRepository.save(document);
+    }
+
+    public void deleteById(Long id) {
+        bookSearchRepository.deleteById(id);
+    }
+
+}

--- a/src/test/java/com/nhnacademy/illuwa/d_book/book/controller/BookControllerTest.java
+++ b/src/test/java/com/nhnacademy/illuwa/d_book/book/controller/BookControllerTest.java
@@ -8,6 +8,7 @@ import com.nhnacademy.illuwa.d_book.book.mapper.BookResponseMapper;
 import com.nhnacademy.illuwa.d_book.book.repository.BookRepository;
 import com.nhnacademy.illuwa.infra.apiclient.AladinBookApiService;
 import com.nhnacademy.illuwa.d_book.book.service.BookService;
+import com.nhnacademy.illuwa.search.service.BookSearchService;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -22,6 +23,7 @@ import java.time.LocalDate;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -54,6 +56,9 @@ public class BookControllerTest {
 
     @MockBean
     private BookResponseMapper bookResponseMapper;
+
+    @MockBean
+    private BookSearchService bookSearchService;
 
     @Test
     @DisplayName("책 검색 성공 - Title")
@@ -101,14 +106,19 @@ public class BookControllerTest {
     }
 
     @Test
-    @Disabled
     void getRegisteredBooks() throws Exception {
+        // given
+        List<BookDetailResponse> mockBooks = List.of(
+                new BookDetailResponse()
+        );
+        given(bookService.getAllBooks()).willReturn(mockBooks);
 
         // when & then
-        mockMvc.perform(get("/books"))
-                .andExpect(status().isOk());
+        mockMvc.perform(get("/api/books"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(mockBooks.size())); // JSON 배열 길이 검증
 
-        verify(bookService).getAllBooksByPaging(any());
+        verify(bookService).getAllBooks(); // 여기 맞게 verify
     }
 
 


### PR DESCRIPTION
## 📝작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명
- `BookService`, `BookController` 내부에 있던 **검색 관련 로직**을 제거
- 새로운 `BookSearchService`, `BookSearchController` 생성
- Elasticsearch 연동 기능을 Search 모듈로 이관

### 리팩토링
- 검색 기능 관련 메서드 삭제 및 이전
- Elasticsearch repository, document 관련 클래스 Search 패키지로 이동
- 테스트 코드 경로 및 Mock 설정 수정

---

- 도서 검색 API 정상 동작 확인
- 기존 도서 조회, 등록, 삭제 API 영향 없음 검증
- 테스트 코드 통과


## 💬리뷰 요구사항(선택)

## Issue Tags
> 아래 # 태그 뒤에 이슈 번호 붙여주세요!
- Closed: #282 
