### PR TITLE
[BUG] 도서 부가정보 포함 상세 dto , giftwrap null값 에러 해결

### DIFF
--- a/src/main/java/com/nhnacademy/illuwa/d_book/book/dto/response/BookDetailWithExtraInfoResponse.java
+++ b/src/main/java/com/nhnacademy/illuwa/d_book/book/dto/response/BookDetailWithExtraInfoResponse.java
@@ -31,7 +31,7 @@ public class BookDetailWithExtraInfoResponse {
     private BigDecimal salePrice;
     private String imgUrl;
 
-    private boolean giftwrap;
+    private Boolean giftwrap;
     private Integer count;
     private Status status;
 


### PR DESCRIPTION
- boolean -> Boolean , Wrapper 객체 적용

## 📝작업 내용
> dto의 필드에서 giftwrap(선물 포장 여부 부분을) boolean -> Boolean으로 설정

## 💬리뷰 요구사항(선택)

## Issue Tags
> 아래 # 태그 뒤에 이슈 번호 붙여주세요!
- Closed: #
