### PR TITLE
[FEAT] N+1 문제 방지를 위한 @EntityGraph 적용

### DIFF
--- a/src/main/java/com/nhnacademy/illuwa/d_book/book/repository/BookRepository.java
+++ b/src/main/java/com/nhnacademy/illuwa/d_book/book/repository/BookRepository.java
@@ -3,13 +3,10 @@ package com.nhnacademy.illuwa.d_book.book.repository;
 import com.nhnacademy.illuwa.d_book.book.entity.Book;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
@@ -17,29 +14,21 @@ import java.util.Optional;
 @Repository
 public interface BookRepository extends JpaRepository<Book, Long>, BookRepositoryCustom {
 
+    @EntityGraph(attributePaths = {"bookImages", "bookTags", "bookCategories"})
     List<Book> findByTitleContaining(String title);
 
-    List<Book> findByDescriptionContaining(String description);
-
-    List<Book> findByAuthor(String author);
-
-    List<Book> findByPublisher(String publisher);
-
+    @EntityGraph(attributePaths = {"bookImages", "bookTags", "bookCategories"})
     Optional<Book> findByIsbn(String isbn);
-
-    List<Book> findBySalePriceBetween(int min, int max);
-    List<Book> findByPublishedDateAfter(LocalDate date);
-    List<Book> findByPublishedDateBefore(LocalDate date);
-
-    Page<Book> findByAuthor(String author, Pageable pageable);
-    Page<Book> findByPublishedDateBetween(LocalDate startDate, LocalDate endDate, Pageable pageable);
-
-    @Modifying
-    @Query("DELETE FROM Book b WHERE b.isbn = :isbn")  // OK - 삭제
-    int deleteByIsbn(@Param("isbn") String isbn);
 
     boolean existsByIsbn(String isbn);
 
+    @EntityGraph(attributePaths = {"bookImages", "bookTags", "bookCategories"})
     Page<Book> findAll(Pageable pageable);
+
+    @EntityGraph(attributePaths = {"bookImages", "bookTags", "bookCategories"})
+    Optional<Book> findById(Long id);
+
+    @EntityGraph(attributePaths = {"bookImages", "bookTags", "bookCategories"})
+    List<Book> findAll();
 
 }

--- a/src/main/java/com/nhnacademy/illuwa/d_book/category/repository/category/CategoryRepository.java
+++ b/src/main/java/com/nhnacademy/illuwa/d_book/category/repository/category/CategoryRepository.java
@@ -1,13 +1,27 @@
 package com.nhnacademy.illuwa.d_book.category.repository.category;
 
 import com.nhnacademy.illuwa.d_book.category.entity.Category;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> , CustomizedCategoryRepository{
+    @EntityGraph(attributePaths = {"childrenCategory", "parentCategory"})
     List<Category> findByParentCategoryIsNull();
 
+    @EntityGraph(attributePaths = {"childrenCategory", "parentCategory"})
     Optional<Category> findByCategoryName(String categoryName);
+
+    @EntityGraph(attributePaths = {"childrenCategory", "parentCategory"})
+    List<Category> findAll();
+
+    @EntityGraph(attributePaths = {"childrenCategory", "parentCategory"})
+    Page<Category> findAll(Pageable pageable);
+
+    @EntityGraph(attributePaths = {"childrenCategory", "parentCategory"})
+    Optional<Category> findById(Long id);
 }

--- a/src/main/java/com/nhnacademy/illuwa/d_book/tag/repository/BookTagRepository.java
+++ b/src/main/java/com/nhnacademy/illuwa/d_book/tag/repository/BookTagRepository.java
@@ -1,15 +1,18 @@
 package com.nhnacademy.illuwa.d_book.tag.repository;
 
 import com.nhnacademy.illuwa.d_book.tag.entity.BookTag;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface BookTagRepository extends JpaRepository<BookTag, Long> {
+    @EntityGraph(attributePaths = {"tag"})
     List<BookTag> findByBookId(Long bookId);
 
     boolean existsByBookIdAndTagId(Long bookId, Long tagId);
 
+    @EntityGraph(attributePaths = {"tag"})
     List<BookTag> findByTagId(Long tagId);
 
     void deleteByBookIdAndTagId(Long bookId, Long tagId);


### PR DESCRIPTION
## 📝작업 내용
- book - tag - category - bookImage에서 N+1 문제 발생 가능성
- @EntityGraph를 연관 관계 entity를 고려해서 적용
- 실제 테스트 비교(수행 시간이 적절해 보이는데 @AOP를 통해 추후에 테스트 예정)

## 💬리뷰 요구사항(선택)
- .
## Issue Tags
> 아래 # 태그 뒤에 이슈 번호 붙여주세요!
- Closed: #
