### PR TITLE
[BUG] 도서 목록 조회 시 발생하는 1+N 해결

### DIFF
--- a/src/main/java/com/nhnacademy/illuwa/d_book/book/entity/Book.java
+++ b/src/main/java/com/nhnacademy/illuwa/d_book/book/entity/Book.java
@@ -53,6 +53,7 @@ public class Book {
 
     @Builder.Default
     @OneToMany(mappedBy = "book", cascade = CascadeType.PERSIST, orphanRemoval = true)
+    @BatchSize(size = 5)
     private List<BookImage> bookImages = new ArrayList<>();
 
     @Embedded
@@ -65,10 +66,12 @@ public class Book {
 
     @Builder.Default
     @OneToMany(mappedBy = "book", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    @BatchSize(size = 10)
     private Set<BookTag> bookTags = new HashSet<>();
 
     @Builder.Default
     @OneToMany(mappedBy = "book", cascade = CascadeType.ALL, orphanRemoval = true)
+    @BatchSize(size = 100)
     private Set<BookCategory> bookCategories = new HashSet<>();
 
 

--- a/src/main/java/com/nhnacademy/illuwa/d_book/book/entity/Book.java
+++ b/src/main/java/com/nhnacademy/illuwa/d_book/book/entity/Book.java
@@ -5,6 +5,8 @@ import com.nhnacademy.illuwa.d_book.category.entity.BookCategory;
 import com.nhnacademy.illuwa.d_book.tag.entity.BookTag;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.BatchSize;
+import org.springframework.data.jpa.repository.EntityGraph;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -67,7 +69,7 @@ public class Book {
 
     @Builder.Default
     @OneToMany(mappedBy = "book", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<BookCategory> bookCategories = new ArrayList<>();
+    private Set<BookCategory> bookCategories = new HashSet<>();
 
 
 

--- a/src/main/java/com/nhnacademy/illuwa/d_book/book/repository/BookRepository.java
+++ b/src/main/java/com/nhnacademy/illuwa/d_book/book/repository/BookRepository.java
@@ -3,6 +3,7 @@ package com.nhnacademy.illuwa.d_book.book.repository;
 import com.nhnacademy.illuwa.d_book.book.entity.Book;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -19,27 +20,15 @@ public interface BookRepository extends JpaRepository<Book, Long>, BookRepositor
 
     List<Book> findByTitleContaining(String title);
 
-    List<Book> findByDescriptionContaining(String description);
-
-    List<Book> findByAuthor(String author);
-
-    List<Book> findByPublisher(String publisher);
-
     Optional<Book> findByIsbn(String isbn);
-
-    List<Book> findBySalePriceBetween(int min, int max);
-    List<Book> findByPublishedDateAfter(LocalDate date);
-    List<Book> findByPublishedDateBefore(LocalDate date);
-
-    Page<Book> findByAuthor(String author, Pageable pageable);
-    Page<Book> findByPublishedDateBetween(LocalDate startDate, LocalDate endDate, Pageable pageable);
-
-    @Modifying
-    @Query("DELETE FROM Book b WHERE b.isbn = :isbn")  // OK - 삭제
-    int deleteByIsbn(@Param("isbn") String isbn);
 
     boolean existsByIsbn(String isbn);
 
+    @EntityGraph(attributePaths = {
+            "bookImages",
+            "bookTags.tag",
+            "bookCategories.category"
+    })
     Page<Book> findAll(Pageable pageable);
 
 }

--- a/src/main/java/com/nhnacademy/illuwa/d_book/category/entity/BookCategory.java
+++ b/src/main/java/com/nhnacademy/illuwa/d_book/category/entity/BookCategory.java
@@ -5,12 +5,14 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.BatchSize;
 
 @Getter
 @Setter
 @NoArgsConstructor
 @Entity
 @Table(name = "book_categories")
+@BatchSize(size = 100)
 public class BookCategory {
 
     @Id

--- a/src/main/java/com/nhnacademy/illuwa/d_book/category/entity/Category.java
+++ b/src/main/java/com/nhnacademy/illuwa/d_book/category/entity/Category.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.BatchSize;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -13,6 +14,7 @@ import java.util.List;
 @Getter
 @NoArgsConstructor
 @Table(name = "categories")
+@BatchSize(size = 100)
 public class Category {
 
     @Id
@@ -40,3 +42,4 @@ public class Category {
     }
 
 }
+

--- a/src/main/java/com/nhnacademy/illuwa/d_book/tag/entity/BookTag.java
+++ b/src/main/java/com/nhnacademy/illuwa/d_book/tag/entity/BookTag.java
@@ -4,11 +4,13 @@ import com.nhnacademy.illuwa.d_book.book.entity.Book;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.BatchSize;
 
 @Entity
 @Getter
 @NoArgsConstructor
 @Table(name = "book_tags")
+@BatchSize(size = 10)
 public class BookTag {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/nhnacademy/illuwa/d_book/tag/entity/Tag.java
+++ b/src/main/java/com/nhnacademy/illuwa/d_book/tag/entity/Tag.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.BatchSize;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -13,6 +14,7 @@ import java.util.List;
 @NoArgsConstructor
 @Entity
 @Table(name = "tags")
+@BatchSize(size = 10)
 public class Tag {
 
     @Id

--- a/src/test/java/com/nhnacademy/illuwa/search/service/BookSearchServiceTest.java
+++ b/src/test/java/com/nhnacademy/illuwa/search/service/BookSearchServiceTest.java
@@ -69,7 +69,7 @@ class BookSearchServiceTest {
     @DisplayName("책 Elasticsearch에 동기화")
     void syncBookToElasticsearch() {
         Book book = new Book();
-        book.setBookCategories(Collections.emptyList());
+        book.setBookCategories(Collections.emptySet());
         book.setBookTags(Collections.emptySet());
 
         bookSearchService.syncBookToElasticsearch(book);


### PR DESCRIPTION
## 📝작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명

BookEntity
	•	bookCategory → bookCategories (단일 → 컬렉션) 필드 타입 변경
	•	@BatchSize(size = 100) 어노테이션 추가
	•	@EntityGraph를 활용한 연관 엔티티 Fetch 최적화 설정

BookService
	•	도서 상세 조회 로직에서 bookCategoryRepository.findByBookId() 제거
	•	대신, book.getBookCategories().stream().findFirst() 방식으로 변경하여 1+N 문제 해결
	•	getAllBooksWithExtraInfo() 내에서도 마찬가지로 컬렉션 직접 활용
연관 엔티티들에 @BatchSize 추가
	•	BookTag
	•	Category
	•	Tag

## 💬리뷰 요구사항(선택)

## Issue Tags
> 아래 # 태그 뒤에 이슈 번호 붙여주세요!
- Closed: #361 
